### PR TITLE
ci: add macOS and Windows to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,19 +37,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
-
-      - name: Get pnpm store directory
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - name: Cache pnpm store
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-node-${{ matrix.node-version }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-node-${{ matrix.node-version }}-pnpm-
+          cache: 'pnpm'
 
       - name: Install dependencies and build
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,19 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'pnpm'
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-node-${{ matrix.node-version }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ matrix.node-version }}-pnpm-
 
       - name: Install dependencies and build
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
         node-version: [ 20.x, 22.x, 24.x ]
 
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,3 +68,14 @@ Right-hand side can be: literal value, `{ref: "path"}` to reference context, or 
 ## Node.js Support
 
 Supports Node.js ^20, ^22, or ^24
+
+## CI/CD
+
+- CI runs on **Ubuntu, macOS, and Windows**
+- Tests run across all supported Node.js versions
+- Primary checks (Snyk, coverage, type tests) run on Ubuntu + Node 24
+
+## Cross-Platform Notes
+
+- Avoid shell-specific glob patterns in npm scripts (let tools handle glob expansion internally)
+- Use forward slashes in paths within config files (ESLint, TypeScript handle this cross-platform)

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build": "pnpm run lint && pnpm run compile",
     "compile": "tsc -p tsconfig.build.json",
     "test:cover": "vitest run --coverage",
-    "lint": "eslint 'src/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\"",
     "ci": "pnpm run lint && pnpm run compile && pnpm run test:tsd && pnpm run test:cover"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build": "pnpm run lint && pnpm run compile",
     "compile": "tsc -p tsconfig.build.json",
     "test:cover": "vitest run --coverage",
-    "lint": "eslint \"src/**/*.ts\"",
+    "lint": "eslint src",
     "ci": "pnpm run lint && pnpm run compile && pnpm run test:tsd && pnpm run test:cover"
   },
   "repository": {


### PR DESCRIPTION
The setup-node action's cache option automatically includes the OS
in the cache key, so no cache collisions will occur.

https://claude.ai/code/session_013Qs5NvWYbFZugkWa3mC62w