### PR TITLE
fix: correct repository URL typo (PrvuoNet -> PruvoNet)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/PrvuoNet/json-expression-eval.git"
+    "url": "git+https://github.com/PruvoNet/json-expression-eval.git"
   },
   "keywords": [
     "evaluate",


### PR DESCRIPTION
## Summary

Fixes a typo in `package.json`'s `repository.url` field: `PrvuoNet` → `PruvoNet`.

## Why

npm publish was failing with a sigstore provenance verification error:

```
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/json-expression-eval
- Error verifying sigstore provenance bundle: Failed to validate repository information:
package.json: "repository.url" is "git+https://github.com/PrvuoNet/json-expression-eval.git",
expected to match "https://github.com/PruvoNet/json-expression-eval" from provenance
```

The provenance bundle (generated from the actual GitHub repo) records `PruvoNet`, but the
typo'd `PrvuoNet` in `package.json` did not match, so verification rejected the publish.

## Test plan

- Re-run the release/publish workflow so a fresh provenance bundle is generated from the corrected `package.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)